### PR TITLE
feat: switch to FastMail MX

### DIFF
--- a/modules/pleroma/postgres.tf
+++ b/modules/pleroma/postgres.tf
@@ -25,6 +25,11 @@ resource "aws_db_instance" "main" {
 
   username = local.postgres_username
   password = random_password.postgres.result
+
+  lifecycle {
+    # FIXME
+    ignore_changes = [engine_version]
+  }
 }
 
 locals {

--- a/workspaces/pleroma/dns.tf
+++ b/workspaces/pleroma/dns.tf
@@ -11,6 +11,11 @@ resource "aws_route53_record" "mx" {
   ]
 }
 
+moved {
+  from = aws_route53_record.google_domains_mx
+  to   = aws_route53_record.mx
+}
+
 # Status page
 resource "aws_route53_record" "status" {
   zone_id = data.aws_route53_zone.main.id

--- a/workspaces/pleroma/dns.tf
+++ b/workspaces/pleroma/dns.tf
@@ -1,16 +1,13 @@
 # Set up MX to receive emails
-resource "aws_route53_record" "google_domains_mx" {
+resource "aws_route53_record" "mx" {
   zone_id = data.aws_route53_zone.main.id
 
   name = local.domain
   type = "MX"
   ttl  = 300
   records = [
-    "5 gmr-smtp-in.l.google.com.",
-    "10 alt1.gmr-smtp-in.l.google.com.",
-    "20 alt2.gmr-smtp-in.l.google.com.",
-    "30 alt3.gmr-smtp-in.l.google.com.",
-    "40 alt4.gmr-smtp-in.l.google.com.",
+    "10 in1-smtp.messagingengine.com.",
+    "20 in2-smtp.messagingengine.com.",
   ]
 }
 


### PR DESCRIPTION
Domain is no longer registered with Google Domains so the free email forwarding service is no longer available.
